### PR TITLE
Rename tour to onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ If you want to add a new language you should update the file
 To generate .pot files you should run:
 
 ```
-ninja -C _build tour-extension-pot
+ninja -C _build onboarding-extension-pot
 ```
 
 To generate .po files you should run:
 
 ```
-ninja -C _build tour-extension-update-po
+ninja -C _build onboarding-extension-update-po
 ```

--- a/data/dbus-interfaces/com.endlessm.onboarding.xml
+++ b/data/dbus-interfaces/com.endlessm.onboarding.xml
@@ -1,5 +1,5 @@
 <node>
-  <interface name="com.endlessm.tour">
+  <interface name="com.endlessm.onboarding">
     <method name="HighlightRect">
       <arg type="u" direction="in" name="x"/>
       <arg type="u" direction="in" name="y"/>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-eos-tour-extension (0.1) eos; urgency=medium
+eos-onboarding-extension (0.1) eos; urgency=medium
 
-  * Initial release of the Tour extension
+  * Initial release of the Onboarding extension
 
  -- Daniel Garcia Moreno <daniel@endlessm.com>  Wed, 27 May 2020 13:09:34 +0200

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: eos-tour-extension
+Source: eos-onboarding-extension
 Section: gnome
 Priority: optional
 Maintainer: Daniel Garcia Moreno <daniel@endlessm.com>
@@ -9,14 +9,14 @@ Build-Depends:
  debhelper-compat (= 12),
  meson (>= 0.40.0)
 Standards-Version: 4.4.0
-Homepage: https://github.com/endlessm/eos-tour-extension
-Vcs-Browser: https://github.com/endlessm/eos-tour-extension
-Vcs-Git: https://github.com/endlessm/eos-tour-extension.git
+Homepage: https://github.com/endlessm/eos-onboarding-extension
+Vcs-Browser: https://github.com/endlessm/eos-onboarding-extension
+Vcs-Git: https://github.com/endlessm/eos-onboarding-extension.git
 
-Package: eos-tour-extension
+Package: eos-onboarding-extension
 Architecture: all
 Depends:
  gnome-shell (>= 3.35),
  ${shlibs:Depends},
  ${misc:Depends}
-Description: Endless OS Tour extension for GNOME Shell
+Description: Endless OS onboarding extension for GNOME Shell

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: Endless OS Tour Extension
-Source: https://github.com/endlessm/eos-tour-extension
+Upstream-Name: Endless OS Onboarding Extension
+Source: https://github.com/endlessm/eos-onboarding-extension
 
 Files: *
 Copyright: 2020 Daniel Garcia Moreno <daniel@endlessm.com>

--- a/debian/files
+++ b/debian/files
@@ -1,2 +1,2 @@
-eos-tour-extension_3.8.0_all.deb gnome optional
-eos-tour-extension_3.8.0_amd64.buildinfo gnome optional
+eos-onboarding-extension_3.8.0_all.deb gnome optional
+eos-onboarding-extension_3.8.0_amd64.buildinfo gnome optional

--- a/extension.js
+++ b/extension.js
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2020 Endless OS LLC.
  *
- * This file is part of eos-tour-extension
- * (see https://github.com/endlessm/eos-tour-extension).
+ * This file is part of eos-onboarding-extension
+ * (see https://github.com/endlessm/eos-onboarding-extension).
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,10 +21,10 @@
 /* exported enable, disable */
 
 const ExtensionUtils = imports.misc.extensionUtils;
-const Tour = ExtensionUtils.getCurrentExtension();
+const Onboarding = ExtensionUtils.getCurrentExtension();
 
 // To import custom files
-const Service = Tour.imports.service;
+const Service = Onboarding.imports.service;
 
 function enable() {
     Service.enable();

--- a/highlight.js
+++ b/highlight.js
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2020 Endless OS LLC.
  *
- * This file is part of eos-tour-extension
- * (see https://github.com/endlessm/eos-tour-extension).
+ * This file is part of eos-onboarding-extension
+ * (see https://github.com/endlessm/eos-onboarding-extension).
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('tour-extension',
+project('onboarding-extension',
   version: '3.8.0',
   meson_version: '>= 0.40.0'
 )
@@ -16,7 +16,7 @@ extra_sources = [
 i18n = import('i18n')
 subdir('po')
 
-uuid = 'eos-tour@endlessm.com'
+uuid = 'eos-onboarding@endlessm.com'
 
 ver_arr = meson.project_version().split('.')
 if ver_arr[1].to_int().is_even()

--- a/metadata.json.in
+++ b/metadata.json.in
@@ -1,8 +1,8 @@
 {
 "uuid": "@uuid@",
-"name": "Tour",
+"name": "Onbarding",
 "description": "Interactive tutorials for gnome desktop",
 "settings-schema": "@settings_schema@",
 "shell-version": ["@shell_version@"],
-"url": "https://github.com/endlessm/eos-tour-extension"
+"url": "https://github.com/endlessm/eos-onbarding-extension"
 }

--- a/service.js
+++ b/service.js
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2020 Endless OS LLC.
  *
- * This file is part of eos-tour-extension
- * (see https://github.com/endlessm/eos-tour-extension).
+ * This file is part of eos-onboarding-extension
+ * (see https://github.com/endlessm/eos-onboarding-extension).
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,24 +25,24 @@ const { Gio, GLib, Shell } = imports.gi;
 const ShellDBus = imports.ui.shellDBus;
 
 const ExtensionUtils = imports.misc.extensionUtils;
-const Tour = ExtensionUtils.getCurrentExtension();
-const Utils = Tour.imports.utils;
-const Highlight = Tour.imports.highlight;
+const Onboarding = ExtensionUtils.getCurrentExtension();
+const Utils = Onboarding.imports.utils;
+const Highlight = Onboarding.imports.highlight;
 
-const IFACE = Utils.loadInterfaceXML('com.endlessm.tour');
+const IFACE = Utils.loadInterfaceXML('com.endlessm.onboarding');
 
 var Service = class {
     constructor() {
         this._propagateEvents = true;
         this._skippable = true;
         this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(IFACE, this);
-        this._nameId = Gio.bus_own_name_on_connection(Gio.DBus.session, 'com.endlessm.tour',
+        this._nameId = Gio.bus_own_name_on_connection(Gio.DBus.session, 'com.endlessm.onboarding',
             Gio.BusNameOwnerFlags.REPLACE, null, null);
 
         try {
-            this._dbusImpl.export(Gio.DBus.session, '/com/endlessm/tour');
+            this._dbusImpl.export(Gio.DBus.session, '/com/endlessm/onboarding');
         } catch (e) {
-            logError(e, 'Cannot export Tour service');
+            logError(e, 'Cannot export Onboarding service');
             return;
         }
     }
@@ -51,7 +51,7 @@ var Service = class {
         try {
             this._dbusImpl.unexport();
         } catch (e) {
-            logError(e, 'Cannot unexport Tour service');
+            logError(e, 'Cannot unexport Onboarding service');
         }
 
         if (this._nameId != 0) {

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2020 Endless OS LLC.
  *
- * This file is part of eos-tour-extension
- * (see https://github.com/endlessm/eos-tour-extension).
+ * This file is part of eos-onboarding-extension
+ * (see https://github.com/endlessm/eos-onboarding-extension).
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -68,13 +68,13 @@ function changeProp(prop, value) {
     const propProxy = new Gio.DBusProxy.new_for_bus_sync(
         Gio.BusType.SESSION,
         0, null,
-        'com.endlessm.tour',
-        '/com/endlessm/tour',
+        'com.endlessm.onboarding',
+        '/com/endlessm/onboarding',
         'org.freedesktop.DBus.Properties',
         null);
 
     const variant = new GLib.Variant('(ssv)',
-        ['com.endlessm.tour', prop, new GLib.Variant('b', value)]);
+        ['com.endlessm.onboarding', prop, new GLib.Variant('b', value)]);
 
     return new Promise((resolve, reject) => {
         propProxy.call('Set', variant, Gio.DBusCallFlags.NONE, -1, null, (proxy, res) => {
@@ -89,9 +89,9 @@ function testInit() {
     proxy = new Gio.DBusProxy.new_for_bus_sync(
         Gio.BusType.SESSION,
         0, null,
-        'com.endlessm.tour',
-        '/com/endlessm/tour',
-        'com.endlessm.tour',
+        'com.endlessm.onboarding',
+        '/com/endlessm/onboarding',
+        'com.endlessm.onboarding',
         null);
 
     proxy.call('Overview', new GLib.Variant('(s)', ['show']), Gio.DBusCallFlags.NONE, -1, null, (proxy, res) => {});

--- a/testFuzzy.js
+++ b/testFuzzy.js
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2020 Endless OS LLC.
  *
- * This file is part of eos-tour-extension
- * (see https://github.com/endlessm/eos-tour-extension).
+ * This file is part of eos-onboarding-extension
+ * (see https://github.com/endlessm/eos-onboarding-extension).
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -44,9 +44,9 @@ function testInit() {
     proxy = new Gio.DBusProxy.new_for_bus_sync(
         Gio.BusType.SESSION,
         0, null,
-        'com.endlessm.tour',
-        '/com/endlessm/tour',
-        'com.endlessm.tour',
+        'com.endlessm.onboarding',
+        '/com/endlessm/onboarding',
+        'com.endlessm.onboarding',
         null);
 
     drawFuzzy('top left', '20% 10%', 'rect')

--- a/utils.js
+++ b/utils.js
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2020 Endless OS LLC.
  *
- * This file is part of eos-tour-extension
- * (see https://github.com/endlessm/eos-tour-extension).
+ * This file is part of eos-onboarding-extension
+ * (see https://github.com/endlessm/eos-onboarding-extension).
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
 /* exported loadInterfaceXML, gettext */
 
 const { Gio } = imports.gi;
-const Gettext = imports.gettext.domain('tour-extension');;
+const Gettext = imports.gettext.domain('onboarding-extension');;
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 
 var gettext = Gettext.gettext;


### PR DESCRIPTION
This rename is done to have a coherent repository name and extension name.

https://phabricator.endlessm.com/T30237