### PR TITLE
Add CloneWindowRole property

### DIFF
--- a/data/dbus-interfaces/com.endlessm.onboarding.xml
+++ b/data/dbus-interfaces/com.endlessm.onboarding.xml
@@ -40,5 +40,6 @@
     <property name="Skippable" type="b" access="readwrite"/>
     <property name="Skip" type="b" access="read"/>
     <property name="PropagateEvents" type="b" access="readwrite"/>
+    <property name="CloneWindowRole" type="s" access="readwrite"/>
   </interface>
 </node>

--- a/service.js
+++ b/service.js
@@ -34,6 +34,7 @@ const IFACE = Utils.loadInterfaceXML('com.endlessm.onboarding');
 var Service = class {
     constructor() {
         this._propagateEvents = true;
+        this._cloneWindowRole = '';
         this._skippable = true;
         this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(IFACE, this);
         this._nameId = Gio.bus_own_name_on_connection(Gio.DBus.session, 'com.endlessm.onboarding',
@@ -121,6 +122,15 @@ var Service = class {
     set PropagateEvents(enabled) {
         this._propagateEvents = enabled;
         this._dbusImpl.emit_property_changed('PropagateEvents', new GLib.Variant('b', enabled));
+    }
+
+    get CloneWindowRole() {
+        return this._cloneWindowRole;
+    }
+
+    set CloneWindowRole(role) {
+        this._cloneWindowRole = role;
+        this._dbusImpl.emit_property_changed('CloneWindowRole', new GLib.Variant('s', role));
     }
 };
 


### PR DESCRIPTION
The highlight overlay is on top of everything on the desktop. This new
property allow to the user to "show" a window above the overlay.

This new property is a window role that will be cloned and drawn on top
of the highlight actor.

This cloned actor is not reactive, so it will not possible to interact
with the cloned window that's on top of the highlight overlay.

https://phabricator.endlessm.com/T30672