### PR TITLE
Add service to clean call

### DIFF
--- a/service.js
+++ b/service.js
@@ -113,7 +113,7 @@ var Service = class {
     }
 
     Clean() {
-        Highlight.clean();
+        Highlight.clean(this);
     }
 
     skip() {


### PR DESCRIPTION
The clean method requires the service object to update the IsHighlight
property. This patch pass the service when the Clean API method is
called directly.

This should fix the issue detected here:
https://github.com/endlessm/clubhouse/pull/1158#issuecomment-691361528